### PR TITLE
Building works on Windows now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ subprojects {subProject ->
     apply plugin: 'eclipse'
     apply from: emmaPlugin
     compileJava.options.fork([memoryMaximumSize: '1024m'])
+    compileJava.options.encoding = 'UTF-8'
     jar.baseName = "modica_$subProject.name"
     
     sourceCompatibility = 1.6


### PR DESCRIPTION
The encoding for java sources is now explicitly set to utf-8 so compiling works on Windows, too (where the default encoding is cp1252).
